### PR TITLE
Fixed Destop and Webapp Issues

### DIFF
--- a/code/ticket_system/ticket_system_web_app/Controllers/ProjectsController.cs
+++ b/code/ticket_system/ticket_system_web_app/Controllers/ProjectsController.cs
@@ -269,8 +269,7 @@ namespace ticket_system_web_app.Controllers
 
             var groupProject = await _context.Projects
                 .Include(proj => proj.Collaborators)
-                .Where(proj => proj.Collaborators.Any(collab =>
-                    collab.Group.Employees.Any(employee => employee.EId == eId)))
+                .Where(proj => proj.Collaborators.Any(collab => collab.Group.Employees.Any(employee => employee.EId == eId) || (collab.Group.ManagerId == eId)))
                 .ToListAsync();
 
             var allRelatedProjects = leadProject

--- a/code/ticket_system/ticket_system_web_app/Data/TicketSystemDbContext.cs
+++ b/code/ticket_system/ticket_system_web_app/Data/TicketSystemDbContext.cs
@@ -174,7 +174,8 @@ namespace ticket_system_web_app.Data
 
         private static Employee tempAdminCreation()
         {
-            var password = "$2a$11$tqFhRcVPxPe/F7g4i2.9c.tms9AlneY5RDZb1SipsY1FQtMcaaecu";
+            // The tempAdmin password is now password.
+            var password = "$2a$11$wQMl3xgNyJ.8MfbEmSI8SuypYgyefazrYrGRAHRz.Kts7AuSk77.e";
             return new Employee
             {
                 EId = 1,


### PR DESCRIPTION
* Allows group managers who are not project leads to view projects they are a part of.
* Now displays tasks in stages that have no groups associated with them on the desktop app.
* Gives a warning if you move a task to a stage that you do not have access to in the desktop app.